### PR TITLE
Check for length change instead of data

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -299,7 +299,7 @@ function createListComponent(_ref) {
 
       this._commitHook();
 
-      if (prevProps.itemData !== this.props.itemData) {
+      if (prevProps.itemData.length !== this.props.itemData.length) {
         this._dataChange();
       }
 

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -293,7 +293,7 @@ function createListComponent(_ref) {
 
       this._commitHook();
 
-      if (prevProps.itemData !== this.props.itemData) {
+      if (prevProps.itemData.length !== this.props.itemData.length) {
         this._dataChange();
       }
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -226,7 +226,7 @@ export default function createListComponent({
       }
 
       this._commitHook();
-      if (prevProps.itemData !== this.props.itemData) {
+      if (prevProps.itemData.length !== this.props.itemData.length) {
         this._dataChange();
       }
 


### PR DESCRIPTION
Array check can cause unneeded false alarms causing to make recursive calls to parent loadMorePosts call

* Can cause an issue with bi-directional scrolling when we move from one set of 30 posts to another but for now this works.

* Iterate on array and compare stringIDs as a better variation which handles all cases.