### PR TITLE
Use animationFrame delay only for chrome

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -717,7 +717,39 @@ function (_Component) {
   return ItemMeasurer;
 }(React.Component);
 
+// From https://stackoverflow.com/a/13348618/2902013
+// please note,
+// that IE11 now returns undefined again for window.chrome
+// and new Opera 30 outputs true for window.chrome
+// but needs to check if window.opr is not undefined
+// and new IE Edge outputs to true now for window.chrome
+// and if not iOS Chrome check
+// so use the below updated condition
+// we return true for electron as well as electron also does not immediately correct scroll
+// similar to chrome and loads another set of posts.
+// chromimum seems to work fine so mostly in near future chrome fixes the issue
+function isBrowserChrome() {
+  var isChromium = window.chrome;
+  var winNav = window.navigator;
+  var vendorName = winNav.vendor;
+  var isOpera = typeof window.opr !== 'undefined';
+  var isIEedge = winNav.userAgent.indexOf('Edge') > -1;
+  var isIOSChrome = winNav.userAgent.match('CriOS');
+  var isElectron = winNav.userAgent.toLowerCase().indexOf(' electron/') > -1;
+
+  if (isIOSChrome || isElectron) {
+    return true;
+  } else if (isChromium !== null && typeof isChromium !== 'undefined' && vendorName === 'Google Inc.' && isOpera === false && isIEedge === false) {
+    return true;
+  }
+
+  return false;
+}
+
 var DEFAULT_ESTIMATED_ITEM_SIZE = 50;
+var isChrome =
+/*#__PURE__*/
+isBrowserChrome();
 
 var getItemMetadata = function getItemMetadata(props, index, instanceProps) {
   var instance = instanceProps.instance,
@@ -975,11 +1007,15 @@ createListComponent({
           if (mountingCorrections === 1) {
             correctScroll();
           } else {
-            if (correctionFrame) {
-              window.cancelAnimationFrame(correctionFrame);
-            }
+            if (isChrome) {
+              if (correctionFrame) {
+                window.cancelAnimationFrame(correctionFrame);
+              }
 
-            correctionFrame = window.requestAnimationFrame(correctScroll);
+              correctionFrame = window.requestAnimationFrame(correctScroll);
+            } else {
+              correctScroll();
+            }
           }
         }
       });

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -710,7 +710,39 @@ function (_Component) {
   return ItemMeasurer;
 }(Component);
 
+// From https://stackoverflow.com/a/13348618/2902013
+// please note,
+// that IE11 now returns undefined again for window.chrome
+// and new Opera 30 outputs true for window.chrome
+// but needs to check if window.opr is not undefined
+// and new IE Edge outputs to true now for window.chrome
+// and if not iOS Chrome check
+// so use the below updated condition
+// we return true for electron as well as electron also does not immediately correct scroll
+// similar to chrome and loads another set of posts.
+// chromimum seems to work fine so mostly in near future chrome fixes the issue
+function isBrowserChrome() {
+  var isChromium = window.chrome;
+  var winNav = window.navigator;
+  var vendorName = winNav.vendor;
+  var isOpera = typeof window.opr !== 'undefined';
+  var isIEedge = winNav.userAgent.indexOf('Edge') > -1;
+  var isIOSChrome = winNav.userAgent.match('CriOS');
+  var isElectron = winNav.userAgent.toLowerCase().indexOf(' electron/') > -1;
+
+  if (isIOSChrome || isElectron) {
+    return true;
+  } else if (isChromium !== null && typeof isChromium !== 'undefined' && vendorName === 'Google Inc.' && isOpera === false && isIEedge === false) {
+    return true;
+  }
+
+  return false;
+}
+
 var DEFAULT_ESTIMATED_ITEM_SIZE = 50;
+var isChrome =
+/*#__PURE__*/
+isBrowserChrome();
 
 var getItemMetadata = function getItemMetadata(props, index, instanceProps) {
   var instance = instanceProps.instance,
@@ -968,11 +1000,15 @@ createListComponent({
           if (mountingCorrections === 1) {
             correctScroll();
           } else {
-            if (correctionFrame) {
-              window.cancelAnimationFrame(correctionFrame);
-            }
+            if (isChrome) {
+              if (correctionFrame) {
+                window.cancelAnimationFrame(correctionFrame);
+              }
 
-            correctionFrame = window.requestAnimationFrame(correctScroll);
+              correctionFrame = window.requestAnimationFrame(correctScroll);
+            } else {
+              correctScroll();
+            }
           }
         }
       });

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -4,10 +4,12 @@ import { createElement } from 'react';
 
 import createListComponent, { defaultItemKey } from './createListComponent';
 import ItemMeasurer from './ItemMeasurer';
+import isBrowserChrome from './isChrome';
 
 import type { Props, ScrollToAlign } from './createListComponent';
 
 const DEFAULT_ESTIMATED_ITEM_SIZE = 50;
+const isChrome = isBrowserChrome();
 
 type DynanmicProps = {|
   estimatedItemSize: number,
@@ -324,10 +326,14 @@ const DynamicSizeList = createListComponent({
             if (mountingCorrections === 1) {
               correctScroll();
             } else {
-              if (correctionFrame) {
-                window.cancelAnimationFrame(correctionFrame);
+              if (isChrome) {
+                if (correctionFrame) {
+                  window.cancelAnimationFrame(correctionFrame);
+                }
+                correctionFrame = window.requestAnimationFrame(correctScroll);
+              } else {
+                correctScroll();
               }
-              correctionFrame = window.requestAnimationFrame(correctScroll);
             }
           }
         }

--- a/src/isChrome.js
+++ b/src/isChrome.js
@@ -1,0 +1,35 @@
+// From https://stackoverflow.com/a/13348618/2902013
+// please note,
+// that IE11 now returns undefined again for window.chrome
+// and new Opera 30 outputs true for window.chrome
+// but needs to check if window.opr is not undefined
+// and new IE Edge outputs to true now for window.chrome
+// and if not iOS Chrome check
+// so use the below updated condition
+
+// we return true for electron as well as electron also does not immediately correct scroll
+// similar to chrome and loads another set of posts.
+// chromimum seems to work fine so mostly in near future chrome fixes the issue
+
+export default function isBrowserChrome() {
+  const isChromium = window.chrome;
+  const winNav = window.navigator;
+  const vendorName = winNav.vendor;
+  const isOpera = typeof window.opr !== 'undefined';
+  const isIEedge = winNav.userAgent.indexOf('Edge') > -1;
+  const isIOSChrome = winNav.userAgent.match('CriOS');
+  const isElectron = winNav.userAgent.toLowerCase().indexOf(' electron/') > -1;
+
+  if (isIOSChrome || isElectron) {
+    return true;
+  } else if (
+    isChromium !== null &&
+    typeof isChromium !== 'undefined' &&
+    vendorName === 'Google Inc.' &&
+    isOpera === false &&
+    isIEedge === false
+  ) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
  * Delay of animationFrame was primariliy used because of an issue in chrome
    where loading older posts does not correct immediately and keeps to the top
    because of scroll momentum
  * Added animation frame differ causes other browsers to show the odd jump
    after scroll correction