### PR TITLE
MM-14861 Fix safari perf issues

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -40,7 +40,6 @@ function requestTimeout(callback, delay) {
   return timeoutID;
 }
 
-var IS_SCROLLING_DEBOUNCE_INTERVAL = 150;
 var defaultItemKey = function defaultItemKey(index, data) {
   return index;
 };
@@ -70,11 +69,9 @@ function createListComponent(_ref) {
       _this = _PureComponent.call(this, props) || this;
       _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       _this._outerRef = void 0;
-      _this._resetIsScrollingTimeoutId = null;
       _this._scrollCorrectionInProgress = false;
       _this._atBottom = true;
       _this.state = {
-        isScrolling: false,
         scrollDirection: 'backward',
         scrollOffset: typeof _this.props.initialScrollOffset === 'number' ? _this.props.initialScrollOffset : 0,
         scrollUpdateWasRequested: false,
@@ -139,17 +136,15 @@ function createListComponent(_ref) {
           if (prevState.scrollOffset === scrollLeft) {
             // Scroll position may have been updated by cDM/cDU,
             // In which case we don't need to trigger another render,
-            // And we don't want to update state.isScrolling.
             return null;
           }
 
           return {
-            isScrolling: true,
             scrollDirection: prevState.scrollOffset < scrollLeft ? 'forward' : 'backward',
             scrollOffset: scrollLeft,
             scrollUpdateWasRequested: false
           };
-        }, _this._resetIsScrollingDebounced);
+        });
       };
 
       _this._onScrollVertical = function (event) {
@@ -183,12 +178,10 @@ function createListComponent(_ref) {
           if (prevState.scrollOffset === scrollTop) {
             // Scroll position may have been updated by cDM/cDU,
             // In which case we don't need to trigger another render,
-            // And we don't want to update state.isScrolling.
             return null;
           }
 
           return {
-            isScrolling: true,
             scrollDirection: prevState.scrollOffset < scrollTop ? 'forward' : 'backward',
             scrollOffset: scrollTop,
             scrollUpdateWasRequested: false,
@@ -196,7 +189,7 @@ function createListComponent(_ref) {
             scrollTop: scrollTop,
             scrollDelta: 0
           };
-        }, _this._resetIsScrollingDebounced);
+        });
       };
 
       _this._outerRefSetter = function (ref) {
@@ -208,26 +201,6 @@ function createListComponent(_ref) {
         } else if (outerRef != null && typeof outerRef === 'object' && outerRef.hasOwnProperty('current')) {
           outerRef.current = ref;
         }
-      };
-
-      _this._resetIsScrollingDebounced = function () {
-        if (_this._resetIsScrollingTimeoutId !== null) {
-          cancelTimeout(_this._resetIsScrollingTimeoutId);
-        }
-
-        _this._resetIsScrollingTimeoutId = requestTimeout(_this._resetIsScrolling, IS_SCROLLING_DEBOUNCE_INTERVAL);
-      };
-
-      _this._resetIsScrolling = function () {
-        _this._resetIsScrollingTimeoutId = null;
-
-        _this.setState({
-          isScrolling: false
-        }, function () {
-          // Clear style cache after state update has been committed.
-          // This way we don't break pure sCU for items that don't use isScrolling param.
-          _this._getItemStyleCache(-1);
-        });
       };
 
       _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
@@ -256,8 +229,6 @@ function createListComponent(_ref) {
       }, function () {
         element.scrollTop = scrollOffset;
         _this2._scrollCorrectionInProgress = false;
-
-        _this2._resetIsScrollingDebounced();
       });
     };
 
@@ -310,10 +281,6 @@ function createListComponent(_ref) {
     };
 
     _proto.componentWillUnmount = function componentWillUnmount() {
-      if (this._resetIsScrollingTimeoutId !== null) {
-        cancelTimeout(this._resetIsScrollingTimeoutId);
-      }
-
       this._unmountHook();
     };
 
@@ -327,7 +294,6 @@ function createListComponent(_ref) {
           outerTagName = _this$props3.outerTagName,
           style = _this$props3.style,
           width = _this$props3.width;
-      var isScrolling = this.state.isScrolling;
       var onScroll = direction === 'vertical' ? this._onScrollVertical : this._onScrollHorizontal;
 
       var items = this._renderItems(); // Read this value AFTER items have been created,
@@ -351,7 +317,6 @@ function createListComponent(_ref) {
         ref: innerRef,
         style: {
           height: direction === 'horizontal' ? '100%' : estimatedTotalSize,
-          pointerEvents: isScrolling ? 'none' : '',
           width: direction === 'horizontal' ? estimatedTotalSize : '100%',
           position: 'relative',
           minHeight: '100%'
@@ -436,9 +401,7 @@ function createListComponent(_ref) {
           itemCount = _this$props5.itemCount,
           itemData = _this$props5.itemData,
           _this$props5$itemKey = _this$props5.itemKey,
-          itemKey = _this$props5$itemKey === void 0 ? defaultItemKey : _this$props5$itemKey,
-          useIsScrolling = _this$props5.useIsScrolling;
-      var isScrolling = this.state.isScrolling;
+          itemKey = _this$props5$itemKey === void 0 ? defaultItemKey : _this$props5$itemKey;
 
       var _this$_getRangeToRend2 = this._getRangeToRender(),
           startIndex = _this$_getRangeToRend2[0],
@@ -452,7 +415,6 @@ function createListComponent(_ref) {
             data: itemData,
             key: itemKey(_index, itemData),
             index: _index,
-            isScrolling: useIsScrolling ? isScrolling : undefined,
             style: this._getItemStyle(_index)
           }));
         }
@@ -468,8 +430,7 @@ function createListComponent(_ref) {
     itemData: undefined,
     outerTagName: 'div',
     overscanCountForward: 30,
-    overscanCountBackward: 10,
-    useIsScrolling: false
+    overscanCountBackward: 10
   }, _temp;
 } // NOTE: I considered further wrapping individual items with a pure ListItem component.
 // This would avoid ever calling the render function for the same index more than once,
@@ -589,16 +550,8 @@ function (_Component) {
       //Heavily inspired from https://github.com/marcj/css-element-queries/blob/master/src/ResizeSensor.js
       //and https://github.com/wnr/element-resize-detector/blob/master/src/detection-strategy/scroll.js
       //For more info http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/#comment-244
-      if (typeof _this._resizeSensorExpand.current.scrollBy === 'function') {
-        _this._resizeSensorExpand.current.scrollBy(height + expandScrollDelta, width + expandScrollDelta);
-
-        _this._resizeSensorShrink.current.scrollBy(2 * height + shrinkScrollDelta, 2 * width + shrinkScrollDelta);
-      } else {
-        _this._resizeSensorExpand.current.scrollLeft = width + expandScrollDelta;
-        _this._resizeSensorExpand.current.scrollTop = height + expandScrollDelta;
-        _this._resizeSensorShrink.current.scrollTop = 2 * height + shrinkScrollDelta;
-        _this._resizeSensorShrink.current.scrollLeft = 2 * width + shrinkScrollDelta;
-      }
+      _this._resizeSensorExpand.current.scrollTop = height + expandScrollDelta;
+      _this._resizeSensorShrink.current.scrollTop = 2 * height + shrinkScrollDelta;
     };
 
     _this.scrollingDiv = function (event) {
@@ -1161,10 +1114,8 @@ createListComponent({
           itemData = _instance$props2.itemData,
           _instance$props2$item = _instance$props2.itemKey,
           itemKey = _instance$props2$item === void 0 ? defaultItemKey : _instance$props2$item,
-          useIsScrolling = _instance$props2.useIsScrolling,
           width = _instance$props2.width,
           skipResizeClass = _instance$props2.skipResizeClass;
-      var isScrolling = instance.state.isScrolling;
 
       var _instance$_getRangeTo3 = instance._getRangeToRender(),
           startIndex = _instance$_getRangeTo3[0],
@@ -1183,8 +1134,7 @@ createListComponent({
 
           var item = React.createElement(children, {
             data: itemData,
-            itemId: itemData[_index2],
-            isScrolling: useIsScrolling ? isScrolling : undefined
+            itemId: itemData[_index2]
           }); // Always wrap children in a ItemMeasurer to detect changes in size.
 
           items.push(React.createElement(ItemMeasurer, {
@@ -1220,7 +1170,7 @@ createListComponent({
   }
 });
 
-var IS_SCROLLING_DEBOUNCE_INTERVAL$1 = 150;
+var IS_SCROLLING_DEBOUNCE_INTERVAL = 150;
 
 var defaultItemKey$1 = function defaultItemKey(_ref) {
   var columnIndex = _ref.columnIndex,
@@ -1362,7 +1312,7 @@ function createGridComponent(_ref2) {
           cancelTimeout(_this._resetIsScrollingTimeoutId);
         }
 
-        _this._resetIsScrollingTimeoutId = requestTimeout(_this._resetIsScrolling, IS_SCROLLING_DEBOUNCE_INTERVAL$1);
+        _this._resetIsScrollingTimeoutId = requestTimeout(_this._resetIsScrolling, IS_SCROLLING_DEBOUNCE_INTERVAL);
       };
 
       _this._resetIsScrolling = function () {

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -471,11 +471,9 @@ const DynamicSizeList = createListComponent({
         itemCount,
         itemData,
         itemKey = defaultItemKey,
-        useIsScrolling,
         width,
         skipResizeClass,
       } = instance.props;
-      const { isScrolling } = instance.state;
 
       const [startIndex, stopIndex] = instance._getRangeToRender();
       const items = [];
@@ -494,7 +492,6 @@ const DynamicSizeList = createListComponent({
           const item = createElement(children, {
             data: itemData,
             itemId: itemData[index],
-            isScrolling: useIsScrolling ? isScrolling : undefined,
           });
 
           // Always wrap children in a ItemMeasurer to detect changes in size.

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -143,24 +143,8 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
     //and https://github.com/wnr/element-resize-detector/blob/master/src/detection-strategy/scroll.js
     //For more info http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/#comment-244
 
-    if (typeof this._resizeSensorExpand.current.scrollBy === 'function') {
-      this._resizeSensorExpand.current.scrollBy(
-        height + expandScrollDelta,
-        width + expandScrollDelta
-      );
-
-      this._resizeSensorShrink.current.scrollBy(
-        2 * height + shrinkScrollDelta,
-        2 * width + shrinkScrollDelta
-      );
-    } else {
-      this._resizeSensorExpand.current.scrollLeft = width + expandScrollDelta;
-      this._resizeSensorExpand.current.scrollTop = height + expandScrollDelta;
-      this._resizeSensorShrink.current.scrollTop =
-        2 * height + shrinkScrollDelta;
-      this._resizeSensorShrink.current.scrollLeft =
-        2 * width + shrinkScrollDelta;
-    }
+    this._resizeSensorExpand.current.scrollTop = height + expandScrollDelta;
+    this._resizeSensorShrink.current.scrollTop = 2 * height + shrinkScrollDelta;
   };
 
   componentWillUnmount() {


### PR DESCRIPTION
 Remove Disabling of pointer events on scroll.
    This causes a serious perf issue as browser needs to calc the styles again for all child elements
    Time spent on browser style invalidations is high. This approach of perf
    boost does not help all that much as browsers internally disable pointer events on scroll now

Removing scroll debounce as well as it just an empty timer we don't need and it sets state on pause of scroll causing a re-render - Not so much of perf boost but its a free gain