### PR TITLE
Stop unnecessary renders of itemMeasure

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -726,6 +726,14 @@ function (_Component) {
     }
   };
 
+  _proto.shouldComponentUpdate = function shouldComponentUpdate(nextProps) {
+    if (nextProps.width !== this.props.width || nextProps.size !== this.props.size) {
+      return true;
+    }
+
+    return false;
+  };
+
   _proto.componentDidUpdate = function componentDidUpdate(prevProps) {
     if (prevProps.size === 0 && this.props.size !== 0 || prevProps.size !== this.props.size) {
       this.positionScrollBars();

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -719,6 +719,14 @@ function (_Component) {
     }
   };
 
+  _proto.shouldComponentUpdate = function shouldComponentUpdate(nextProps) {
+    if (nextProps.width !== this.props.width || nextProps.size !== this.props.size) {
+      return true;
+    }
+
+    return false;
+  };
+
   _proto.componentDidUpdate = function componentDidUpdate(prevProps) {
     if (prevProps.size === 0 && this.props.size !== 0 || prevProps.size !== this.props.size) {
       this.positionScrollBars();

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -125,6 +125,16 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
     }
   }
 
+  shouldComponentUpdate(nextProps) {
+    if (
+      nextProps.width !== this.props.width ||
+      nextProps.size !== this.props.size
+    ) {
+      return true;
+    }
+    return false;
+  }
+
   componentDidUpdate(prevProps) {
     if (
       (prevProps.size === 0 && this.props.size !== 0) ||


### PR DESCRIPTION
 * render only when height or width changes