### PR TITLE
MM-15681 Fix for channel position when initRangeRender is less than the number of items

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -74,8 +74,9 @@ function createListComponent(_ref) {
       _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       _this._outerRef = void 0;
       _this._scrollCorrectionInProgress = false;
-      _this._atBottom = true;
       _this._scrollByCorrection = null;
+      _this._keepScrollPosition = false;
+      _this._keepScrollToBottom = false;
       _this.state = {
         scrollDirection: 'backward',
         scrollOffset: typeof _this.props.initialScrollOffset === 'number' ? _this.props.initialScrollOffset : 0,
@@ -328,6 +329,11 @@ function createListComponent(_ref) {
 
         if (_scrollDirection !== prevScrollDirection || _scrollOffset !== prevScrollOffset || _scrollUpdateWasRequested !== prevScrollUpdateWasRequested) {
           this._callPropsCallbacks();
+        }
+
+        if (!prevState.scrolledToInitIndex) {
+          this._keepScrollPosition = false;
+          this._keepScrollToBottom = false;
         }
       }
 
@@ -962,14 +968,14 @@ createListComponent({
 
       var element = instance._outerRef;
 
-      if (instance.props.height + element.scrollTop >= instanceProps.totalMeasuredSize - 10) {
+      if (instance.props.height + element.scrollTop >= instanceProps.totalMeasuredSize - 10 || instance._keepScrollToBottom) {
         generateOffsetMeasurements(props, index, instanceProps);
         instance.scrollToItem(0, 'end');
         instance.forceUpdate();
         return;
       }
 
-      if (forceScrollCorrection) {
+      if (forceScrollCorrection || instance._keepScrollPosition) {
         var delta = newSize - oldSize;
 
         var _instance$_getRangeTo = instance._getRangeToRender(element.scrollTop),
@@ -1077,6 +1083,12 @@ createListComponent({
         instance.setState({
           scrolledToInitIndex: true
         });
+
+        if (_index === 0) {
+          instance._keepScrollToBottom = true;
+        } else {
+          instance._keepScrollPosition = true;
+        }
       }
     };
 

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -67,8 +67,9 @@ function createListComponent(_ref) {
       _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       _this._outerRef = void 0;
       _this._scrollCorrectionInProgress = false;
-      _this._atBottom = true;
       _this._scrollByCorrection = null;
+      _this._keepScrollPosition = false;
+      _this._keepScrollToBottom = false;
       _this.state = {
         scrollDirection: 'backward',
         scrollOffset: typeof _this.props.initialScrollOffset === 'number' ? _this.props.initialScrollOffset : 0,
@@ -321,6 +322,11 @@ function createListComponent(_ref) {
 
         if (_scrollDirection !== prevScrollDirection || _scrollOffset !== prevScrollOffset || _scrollUpdateWasRequested !== prevScrollUpdateWasRequested) {
           this._callPropsCallbacks();
+        }
+
+        if (!prevState.scrolledToInitIndex) {
+          this._keepScrollPosition = false;
+          this._keepScrollToBottom = false;
         }
       }
 
@@ -955,14 +961,14 @@ createListComponent({
 
       var element = instance._outerRef;
 
-      if (instance.props.height + element.scrollTop >= instanceProps.totalMeasuredSize - 10) {
+      if (instance.props.height + element.scrollTop >= instanceProps.totalMeasuredSize - 10 || instance._keepScrollToBottom) {
         generateOffsetMeasurements(props, index, instanceProps);
         instance.scrollToItem(0, 'end');
         instance.forceUpdate();
         return;
       }
 
-      if (forceScrollCorrection) {
+      if (forceScrollCorrection || instance._keepScrollPosition) {
         var delta = newSize - oldSize;
 
         var _instance$_getRangeTo = instance._getRangeToRender(element.scrollTop),
@@ -1070,6 +1076,12 @@ createListComponent({
         instance.setState({
           scrolledToInitIndex: true
         });
+
+        if (_index === 0) {
+          instance._keepScrollToBottom = true;
+        } else {
+          instance._keepScrollPosition = true;
+        }
       }
     };
 

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -262,7 +262,8 @@ const DynamicSizeList = createListComponent({
 
       if (
         instance.props.height + element.scrollTop >=
-        instanceProps.totalMeasuredSize - 10
+          instanceProps.totalMeasuredSize - 10 ||
+        instance._keepScrollToBottom
       ) {
         generateOffsetMeasurements(props, index, instanceProps);
         instance.scrollToItem(0, 'end');
@@ -270,7 +271,7 @@ const DynamicSizeList = createListComponent({
         return;
       }
 
-      if (forceScrollCorrection) {
+      if (forceScrollCorrection || instance._keepScrollPosition) {
         const delta = newSize - oldSize;
         const [, , visibleStartIndex] = instance._getRangeToRender(
           element.scrollTop
@@ -374,6 +375,12 @@ const DynamicSizeList = createListComponent({
         instance.setState({
           scrolledToInitIndex: true,
         });
+
+        if (index === 0) {
+          instance._keepScrollToBottom = true;
+        } else {
+          instance._keepScrollPosition = true;
+        }
       }
     };
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -126,8 +126,9 @@ export default function createListComponent({
     _instanceProps: any = initInstanceProps(this.props, this);
     _outerRef: ?HTMLDivElement;
     _scrollCorrectionInProgress = false;
-    _atBottom = true;
     _scrollByCorrection = null;
+    _keepScrollPosition = false;
+    _keepScrollToBottom = false;
     static defaultProps = {
       direction: 'vertical',
       innerTagName: 'div',
@@ -280,6 +281,10 @@ export default function createListComponent({
           scrollUpdateWasRequested !== prevScrollUpdateWasRequested
         ) {
           this._callPropsCallbacks();
+        }
+        if (!prevState.scrolledToInitIndex) {
+          this._keepScrollPosition = false;
+          this._keepScrollToBottom = false;
         }
       }
 


### PR DESCRIPTION
Issue: With initRangeToRender we mount only part of few posts which were needed by using `scrolledToInitIndex` flag.

https://github.com/mattermost/react-window/blob/feature/reverseScroll/src/createListComponent.js#L595-L600.

If there any other render cycle is triggered following this then virt list returns the actual range which will can be at max of 160 items so the change of 50 items to 160(Max limit) is what causes the scroll correction issue

So the first mount loads 50 items and scrolls to the bottom if this is immediately is followed by another trigger which mounts more posts on top causing UI to loose scroll position.

This adds a instance flag to check if there is any mount of new posts between these instance and correct accordingly.

This is not just for keeping position to the bottom but also for recurring visit to a channel which can have a lot of unread as well because we mount part of the list around unread posts which is not at the bottom and we need to lock the position of scroll for these scenarios.