### PR TITLE
MM-15733  Use scrolloffset state instead of element.scrollTop value for fixing scroll position

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -978,7 +978,7 @@ createListComponent({
       if (forceScrollCorrection || instance._keepScrollPosition) {
         var delta = newSize - oldSize;
 
-        var _instance$_getRangeTo = instance._getRangeToRender(element.scrollTop),
+        var _instance$_getRangeTo = instance._getRangeToRender(instance.state.scrollOffset),
             visibleStartIndex = _instance$_getRangeTo[2];
 
         generateOffsetMeasurements(props, index, instanceProps);

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -971,7 +971,7 @@ createListComponent({
       if (forceScrollCorrection || instance._keepScrollPosition) {
         var delta = newSize - oldSize;
 
-        var _instance$_getRangeTo = instance._getRangeToRender(element.scrollTop),
+        var _instance$_getRangeTo = instance._getRangeToRender(instance.state.scrollOffset),
             visibleStartIndex = _instance$_getRangeTo[2];
 
         generateOffsetMeasurements(props, index, instanceProps);

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -274,7 +274,7 @@ const DynamicSizeList = createListComponent({
       if (forceScrollCorrection || instance._keepScrollPosition) {
         const delta = newSize - oldSize;
         const [, , visibleStartIndex] = instance._getRangeToRender(
-          element.scrollTop
+          instance.state.scrollOffset
         );
         generateOffsetMeasurements(props, index, instanceProps);
         if (index < visibleStartIndex + 1) {


### PR DESCRIPTION
Here element.scrollTop will be 0 at times if the browser has not corrected scroll to position before trying to lock the position. Instead using state offset variable for determining `_getRangeToRender`