### PR TITLE
Fix for re-render of items when itemCount changes

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -738,7 +738,7 @@ function (_Component) {
   };
 
   _proto.shouldComponentUpdate = function shouldComponentUpdate(nextProps) {
-    if (nextProps.width !== this.props.width || nextProps.size !== this.props.size) {
+    if (nextProps.width !== this.props.width || nextProps.size !== this.props.size || nextProps.itemCount !== this.props.itemCount) {
       return true;
     }
 
@@ -1143,7 +1143,8 @@ createListComponent({
               itemId: itemKey(_index2),
               width: width,
               skipResizeClass: skipResizeClass,
-              onUnmount: onItemRowUnmount
+              onUnmount: onItemRowUnmount,
+              itemCount: itemCount
             }));
           } else {
             items.push(React.createElement('div', {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -731,7 +731,7 @@ function (_Component) {
   };
 
   _proto.shouldComponentUpdate = function shouldComponentUpdate(nextProps) {
-    if (nextProps.width !== this.props.width || nextProps.size !== this.props.size) {
+    if (nextProps.width !== this.props.width || nextProps.size !== this.props.size || nextProps.itemCount !== this.props.itemCount) {
       return true;
     }
 
@@ -1136,7 +1136,8 @@ createListComponent({
               itemId: itemKey(_index2),
               width: width,
               skipResizeClass: skipResizeClass,
-              onUnmount: onItemRowUnmount
+              onUnmount: onItemRowUnmount,
+              itemCount: itemCount
             }));
           } else {
             items.push(createElement('div', {

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -448,6 +448,7 @@ const DynamicSizeList = createListComponent({
                 width,
                 skipResizeClass,
                 onUnmount: onItemRowUnmount,
+                itemCount,
               })
             );
           } else {

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -128,7 +128,8 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
   shouldComponentUpdate(nextProps) {
     if (
       nextProps.width !== this.props.width ||
-      nextProps.size !== this.props.size
+      nextProps.size !== this.props.size ||
+      nextProps.itemCount !== this.props.itemCount
     ) {
       return true;
     }


### PR DESCRIPTION
When new items are added to the dynamic list the callback here https://github.com/mattermost/mattermost-webapp/blob/c9d8a1aa9dfe26574d25a88e942ef88bc5f9ebad/components/post_view/post_list_virtualized/post_list_virtualized.jsx#L308 is not called as itemMeasurer is not called on itemCount change.

This Fixes two issues 
1. The comment here at https://mattermost.atlassian.net/browse/MM-14948?focusedCommentId=61220&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-61220. As the callback is not called when new posts are added it does not remove the profile picture.

2. https://github.com/mattermost/mattermost-webapp/pull/2806 Classes added here dynamically will not re-render when date separator is removed at the top after loading more posts. 