### PR TITLE
MM-14861 Safari perf improvement

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -40,6 +40,10 @@ function isBrowserChrome() {
 
   return false;
 }
+function isBrowserSafari() {
+  var userAgent = window.navigator.userAgent;
+  return userAgent.indexOf('Safari') !== -1 && userAgent.indexOf('Chrome') === -1;
+}
 
 var isChrome =
 /*#__PURE__*/
@@ -559,6 +563,10 @@ var validateSharedProps = function validateSharedProps(_ref2) {
   }
 };
 
+var isSafari =
+/*#__PURE__*/
+isBrowserSafari();
+
 var scrollBarWidth = 8;
 var scrollableContainerStyles = {
   display: 'inline',
@@ -634,6 +642,7 @@ function (_Component) {
     _this._resizeSensorExpand = React__default.createRef();
     _this._resizeSensorShrink = React__default.createRef();
     _this._positionScrollbarsRef = null;
+    _this._measureItemAnimFrame = null;
 
     _this.positionScrollBars = function (height, width) {
       if (height === void 0) {
@@ -724,11 +733,19 @@ function (_Component) {
   var _proto = ItemMeasurer.prototype;
 
   _proto.componentDidMount = function componentDidMount() {
+    var _this2 = this;
+
     var node = reactDom.findDOMNode(this);
     this._node = node; // Force sync measure for the initial mount.
     // This is necessary to support the DynamicSizeList layout logic.
 
-    this._measureItem(false);
+    if (isSafari && this.props.size) {
+      this._measureItemAnimFrame = window.requestAnimationFrame(function () {
+        _this2._measureItem(false);
+      });
+    } else {
+      this._measureItem(false);
+    }
 
     if (this.props.size) {
       // Don't wait for positioning scrollbars when we have size
@@ -754,6 +771,10 @@ function (_Component) {
   _proto.componentWillUnmount = function componentWillUnmount() {
     if (this._positionScrollbarsRef) {
       window.cancelAnimationFrame(this._positionScrollbarsRef);
+    }
+
+    if (this._measureItemAnimFrame) {
+      window.cancelAnimationFrame(this._measureItemAnimFrame);
     }
 
     var _this$props2 = this.props,

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -33,6 +33,10 @@ function isBrowserChrome() {
 
   return false;
 }
+function isBrowserSafari() {
+  var userAgent = window.navigator.userAgent;
+  return userAgent.indexOf('Safari') !== -1 && userAgent.indexOf('Chrome') === -1;
+}
 
 var isChrome =
 /*#__PURE__*/
@@ -552,6 +556,10 @@ var validateSharedProps = function validateSharedProps(_ref2) {
   }
 };
 
+var isSafari =
+/*#__PURE__*/
+isBrowserSafari();
+
 var scrollBarWidth = 8;
 var scrollableContainerStyles = {
   display: 'inline',
@@ -627,6 +635,7 @@ function (_Component) {
     _this._resizeSensorExpand = React.createRef();
     _this._resizeSensorShrink = React.createRef();
     _this._positionScrollbarsRef = null;
+    _this._measureItemAnimFrame = null;
 
     _this.positionScrollBars = function (height, width) {
       if (height === void 0) {
@@ -717,11 +726,19 @@ function (_Component) {
   var _proto = ItemMeasurer.prototype;
 
   _proto.componentDidMount = function componentDidMount() {
+    var _this2 = this;
+
     var node = findDOMNode(this);
     this._node = node; // Force sync measure for the initial mount.
     // This is necessary to support the DynamicSizeList layout logic.
 
-    this._measureItem(false);
+    if (isSafari && this.props.size) {
+      this._measureItemAnimFrame = window.requestAnimationFrame(function () {
+        _this2._measureItem(false);
+      });
+    } else {
+      this._measureItem(false);
+    }
 
     if (this.props.size) {
       // Don't wait for positioning scrollbars when we have size
@@ -747,6 +764,10 @@ function (_Component) {
   _proto.componentWillUnmount = function componentWillUnmount() {
     if (this._positionScrollbarsRef) {
       window.cancelAnimationFrame(this._positionScrollbarsRef);
+    }
+
+    if (this._measureItemAnimFrame) {
+      window.cancelAnimationFrame(this._measureItemAnimFrame);
     }
 
     var _this$props2 = this.props,

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -2,7 +2,7 @@
 
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
-import isBrowserChrome from './isChrome';
+import { isBrowserChrome } from './userAgent';
 
 const isChrome = isBrowserChrome();
 export type ScrollToAlign = 'auto' | 'center' | 'start' | 'end';

--- a/src/userAgent.js
+++ b/src/userAgent.js
@@ -11,7 +11,7 @@
 // similar to chrome and loads another set of posts.
 // chromimum seems to work fine so mostly in near future chrome fixes the issue
 
-export default function isBrowserChrome() {
+export function isBrowserChrome() {
   const isChromium = window.chrome;
   const winNav = window.navigator;
   const vendorName = winNav.vendor;
@@ -32,4 +32,11 @@ export default function isBrowserChrome() {
     return true;
   }
   return false;
+}
+
+export function isBrowserSafari() {
+  const userAgent = window.navigator.userAgent;
+  return (
+    userAgent.indexOf('Safari') !== -1 && userAgent.indexOf('Chrome') === -1
+  );
 }


### PR DESCRIPTION
  * Delay measuring of post by an animationFrame request when on safari and if the size of the post
    already exists. This prevents layout trash caused by requesting for node.offsetHeight.



