### PR TITLE
MM-16099 Fix for cancellation of scroll correction on immediate calls

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -260,10 +260,6 @@ function createListComponent(_ref) {
         };
       }, function () {
         if (isChrome && useAnimationFrame) {
-          if (_this2._scrollByCorrection) {
-            window.cancelAnimationFrame(_this2._scrollByCorrection);
-          }
-
           _this2._scrollByCorrection = window.requestAnimationFrame(_this2.scrollBy(_this2.state.scrollOffset, _this2.state.scrollByValue));
         } else {
           _this2.scrollBy(_this2.state.scrollOffset, _this2.state.scrollByValue)();
@@ -371,6 +367,10 @@ function createListComponent(_ref) {
 
     _proto.componentWillUnmount = function componentWillUnmount() {
       this._unmountHook();
+
+      if (this._scrollByCorrection) {
+        window.cancelAnimationFrame(this._scrollByCorrection);
+      }
     };
 
     _proto.render = function render() {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -253,10 +253,6 @@ function createListComponent(_ref) {
         };
       }, function () {
         if (isChrome && useAnimationFrame) {
-          if (_this2._scrollByCorrection) {
-            window.cancelAnimationFrame(_this2._scrollByCorrection);
-          }
-
           _this2._scrollByCorrection = window.requestAnimationFrame(_this2.scrollBy(_this2.state.scrollOffset, _this2.state.scrollByValue));
         } else {
           _this2.scrollBy(_this2.state.scrollOffset, _this2.state.scrollByValue)();
@@ -364,6 +360,10 @@ function createListComponent(_ref) {
 
     _proto.componentWillUnmount = function componentWillUnmount() {
       this._unmountHook();
+
+      if (this._scrollByCorrection) {
+        window.cancelAnimationFrame(this._scrollByCorrection);
+      }
     };
 
     _proto.render = function render() {

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -193,9 +193,6 @@ export default function createListComponent({
         }),
         () => {
           if (isChrome && useAnimationFrame) {
-            if (this._scrollByCorrection) {
-              window.cancelAnimationFrame(this._scrollByCorrection);
-            }
             this._scrollByCorrection = window.requestAnimationFrame(
               this.scrollBy(this.state.scrollOffset, this.state.scrollByValue)
             );
@@ -328,6 +325,9 @@ export default function createListComponent({
 
     componentWillUnmount() {
       this._unmountHook();
+      if (this._scrollByCorrection) {
+        window.cancelAnimationFrame(this._scrollByCorrection);
+      }
     }
 
     render() {


### PR DESCRIPTION
  * This cancels the previous scroll correction request which is undesirable.

When Last call is made for posts in a channel, state is set to atEnd 
https://github.com/mattermost/mattermost-webapp/blob/122dae8cebe685ec2bd7487149fc17f643593245/components/post_view/post_list_virtualized/post_list_virtualized.jsx#L253-L255 
and along with this there is a change in `post props` as last bunch of posts loaded calling this scroll correction twice 
https://github.com/mattermost/mattermost-webapp/blob/122dae8cebe685ec2bd7487149fc17f643593245/components/post_view/post_list_virtualized/post_list_virtualized.jsx#L181

So the cancel animation frame cancels the previous correction resulting in keeping the position at the top. This PR removes cancelAnimationFrame from header and moves it to unMount just so we dont cause any memory leaks