### PR TITLE
MM-16381 Fix for channel intro not displaying at times

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -339,7 +339,7 @@ function createListComponent(_ref) {
 
       this._commitHook();
 
-      if (prevProps.itemData.length !== this.props.itemData.length) {
+      if (prevProps.itemData !== this.props.itemData) {
         this._dataChange();
       }
 
@@ -486,7 +486,7 @@ function createListComponent(_ref) {
       var minValue = Math.max(0, stopIndex - overscanBackward);
       var maxValue = Math.max(0, Math.min(itemCount - 1, startIndex + overscanForward));
 
-      while (!getItemSize(this.props, maxValue, this._instanceProps) && maxValue > 0) {
+      while (!getItemSize(this.props, maxValue, this._instanceProps) && maxValue > 0 && this._instanceProps.totalMeasuredSize > this.props.height) {
         maxValue--;
       }
 

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -332,7 +332,7 @@ function createListComponent(_ref) {
 
       this._commitHook();
 
-      if (prevProps.itemData.length !== this.props.itemData.length) {
+      if (prevProps.itemData !== this.props.itemData) {
         this._dataChange();
       }
 
@@ -479,7 +479,7 @@ function createListComponent(_ref) {
       var minValue = Math.max(0, stopIndex - overscanBackward);
       var maxValue = Math.max(0, Math.min(itemCount - 1, startIndex + overscanForward));
 
-      while (!getItemSize(this.props, maxValue, this._instanceProps) && maxValue > 0) {
+      while (!getItemSize(this.props, maxValue, this._instanceProps) && maxValue > 0 && this._instanceProps.totalMeasuredSize > this.props.height) {
         maxValue--;
       }
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -286,7 +286,7 @@ export default function createListComponent({
       }
 
       this._commitHook();
-      if (prevProps.itemData.length !== this.props.itemData.length) {
+      if (prevProps.itemData !== this.props.itemData) {
         this._dataChange();
       }
 
@@ -592,7 +592,8 @@ export default function createListComponent({
 
       while (
         !getItemSize(this.props, maxValue, this._instanceProps) &&
-        maxValue > 0
+        maxValue > 0 &&
+        this._instanceProps.totalMeasuredSize > this.props.height
       ) {
         maxValue--;
       }


### PR DESCRIPTION
Ticket link: https://mattermost.atlassian.net/browse/MM-16381

`props.itemData` length might not change at all times as it can be changing from `more messages loader` to channel intro causing an issue with trigger of `_dataChange`

When filtering items which are not mounted from top we filtering `channel intro` as it will be part of the rangeToRender when there are lot of system messages and the resulted channel view is less than a single page.