### PR TITLE
MM-11505 Force scroll correction to bottom based on a prop correctScrollToBottom

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -841,26 +841,20 @@ var generateOffsetMeasurements = function generateOffsetMeasurements(props, inde
   }
 };
 
-var findNearestItemBinarySearch = function findNearestItemBinarySearch(props, instanceProps, high, low, offset) {
-  while (low < high) {
-    var offsetNew = offset;
-    var middle = low + Math.floor((high - low) / 2);
-    var currentOffset = getItemMetadata(props, middle, instanceProps).offset;
+var findNearestItemBinarySearch = function findNearestItemBinarySearch(props, instanceProps, high, low, scrollOffset) {
+  var index = low;
 
-    if (currentOffset === offsetNew) {
-      return middle;
-    } else if (currentOffset > offsetNew) {
-      low = middle + 1;
-    } else if (currentOffset < offsetNew) {
-      high = middle - 1;
+  while (low <= high) {
+    var currentOffset = getItemMetadata(props, low, instanceProps).offset;
+
+    if (scrollOffset - currentOffset <= 0) {
+      index = low;
     }
+
+    low++;
   }
 
-  if (low > 0) {
-    return low - 1;
-  } else {
-    return 0;
-  }
+  return index;
 };
 
 var getEstimatedTotalSize = function getEstimatedTotalSize(_ref, _ref2) {
@@ -988,8 +982,9 @@ createListComponent({
       }
 
       var element = instance._outerRef;
+      var wasAtBottom = instance.props.height + element.scrollTop >= instanceProps.totalMeasuredSize - 10;
 
-      if (instance.props.height + element.scrollTop >= instanceProps.totalMeasuredSize - 10 || instance._keepScrollToBottom) {
+      if ((wasAtBottom || instance._keepScrollToBottom) && instance.props.correctScrollToBottom) {
         generateOffsetMeasurements(props, index, instanceProps);
         instance.scrollToItem(0, 'end');
         instance.forceUpdate();

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -834,26 +834,20 @@ var generateOffsetMeasurements = function generateOffsetMeasurements(props, inde
   }
 };
 
-var findNearestItemBinarySearch = function findNearestItemBinarySearch(props, instanceProps, high, low, offset) {
-  while (low < high) {
-    var offsetNew = offset;
-    var middle = low + Math.floor((high - low) / 2);
-    var currentOffset = getItemMetadata(props, middle, instanceProps).offset;
+var findNearestItemBinarySearch = function findNearestItemBinarySearch(props, instanceProps, high, low, scrollOffset) {
+  var index = low;
 
-    if (currentOffset === offsetNew) {
-      return middle;
-    } else if (currentOffset > offsetNew) {
-      low = middle + 1;
-    } else if (currentOffset < offsetNew) {
-      high = middle - 1;
+  while (low <= high) {
+    var currentOffset = getItemMetadata(props, low, instanceProps).offset;
+
+    if (scrollOffset - currentOffset <= 0) {
+      index = low;
     }
+
+    low++;
   }
 
-  if (low > 0) {
-    return low - 1;
-  } else {
-    return 0;
-  }
+  return index;
 };
 
 var getEstimatedTotalSize = function getEstimatedTotalSize(_ref, _ref2) {
@@ -981,8 +975,9 @@ createListComponent({
       }
 
       var element = instance._outerRef;
+      var wasAtBottom = instance.props.height + element.scrollTop >= instanceProps.totalMeasuredSize - 10;
 
-      if (instance.props.height + element.scrollTop >= instanceProps.totalMeasuredSize - 10 || instance._keepScrollToBottom) {
+      if ((wasAtBottom || instance._keepScrollToBottom) && instance.props.correctScrollToBottom) {
         generateOffsetMeasurements(props, index, instanceProps);
         instance.scrollToItem(0, 'end');
         instance.forceUpdate();

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -81,26 +81,17 @@ const findNearestItemBinarySearch = (
   instanceProps: InstanceProps,
   high: number,
   low: number,
-  offset: number
+  scrollOffset: number
 ): number => {
-  while (low < high) {
-    const offsetNew = offset;
-    const middle = low + Math.floor((high - low) / 2);
-    const currentOffset = getItemMetadata(props, middle, instanceProps).offset;
-
-    if (currentOffset === offsetNew) {
-      return middle;
-    } else if (currentOffset > offsetNew) {
-      low = middle + 1;
-    } else if (currentOffset < offsetNew) {
-      high = middle - 1;
+  let index = low;
+  while (low <= high) {
+    var currentOffset = getItemMetadata(props, low, instanceProps).offset;
+    if (scrollOffset - currentOffset <= 0) {
+      index = low;
     }
+    low++;
   }
-  if (low > 0) {
-    return low - 1;
-  } else {
-    return 0;
-  }
+  return index;
 };
 
 const getEstimatedTotalSize = (
@@ -259,11 +250,13 @@ const DynamicSizeList = createListComponent({
       }
 
       const element = ((instance._outerRef: any): HTMLDivElement);
+      const wasAtBottom =
+        instance.props.height + element.scrollTop >=
+        instanceProps.totalMeasuredSize - 10;
 
       if (
-        instance.props.height + element.scrollTop >=
-          instanceProps.totalMeasuredSize - 10 ||
-        instance._keepScrollToBottom
+        (wasAtBottom || instance._keepScrollToBottom) &&
+        instance.props.correctScrollToBottom
       ) {
         generateOffsetMeasurements(props, index, instanceProps);
         instance.scrollToItem(0, 'end');


### PR DESCRIPTION
  * This will prevent auto scroll correction to bottom when loading new posts at the bottom

The new prop will be passed from webapp with a condition not to correct to bottom if not all posts are loaded in the channel. https://github.com/mattermost/mattermost-webapp/pull/3049/files#diff-ed9c9fcbf6bfc491f3c9c73bfd339e4aR509

This PR also fixes https://mattermost.atlassian.net/browse/MM-16833.
The above issue happens because of binary search. The sizes of all the posts at the start might not exist making the binary search obsolete. 
if there are `150` posts and if initRange is from `[75, 150]` posts above `75` are mounted and hence any offset below 75 will be `0`

Binary search fails here because the value checked for offset will be (150 + 0) / 2 = `75` as the offset condition is false it checks for `(75+0)` / 2 and so on,  returning 0 at the end causing an issue with `rangeToRender` func. so changing this to be linear search 
