### PR TITLE
Set height state on change of it with onScroll event

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -195,7 +195,7 @@ function createListComponent(_ref) {
           return;
         }
 
-        if (_this.state.scrollHeight !== 0 && scrollHeight !== _this.state.scrollHeight) {
+        if (scrollHeight !== _this.state.scrollHeight) {
           _this.setState({
             scrollHeight: scrollHeight
           });

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -188,7 +188,7 @@ function createListComponent(_ref) {
           return;
         }
 
-        if (_this.state.scrollHeight !== 0 && scrollHeight !== _this.state.scrollHeight) {
+        if (scrollHeight !== _this.state.scrollHeight) {
           _this.setState({
             scrollHeight: scrollHeight
           });

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -666,10 +666,7 @@ export default function createListComponent({
         return;
       }
 
-      if (
-        this.state.scrollHeight !== 0 &&
-        scrollHeight !== this.state.scrollHeight
-      ) {
+      if (scrollHeight !== this.state.scrollHeight) {
         this.setState({
           scrollHeight,
         });


### PR DESCRIPTION
initially height state wasn't used all that much it was a mainly used for scroll correction in absolute positioning. 

Now this is used in webapp to determine if channel is at the bottom so this needs to be set for any height change.