### PR TITLE
MM-17385 Adding a delay in animationFrame for initScrollIndex state set

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -81,6 +81,7 @@ function createListComponent(_ref) {
       _this._scrollByCorrection = null;
       _this._keepScrollPosition = false;
       _this._keepScrollToBottom = false;
+      _this._initScrollAnimationFrameRequest = null;
       _this.state = {
         scrollDirection: 'backward',
         scrollOffset: typeof _this.props.initialScrollOffset === 'number' ? _this.props.initialScrollOffset : 0,
@@ -1090,14 +1091,20 @@ createListComponent({
     };
 
     instance._commitHook = function () {
-      if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length) {
+      if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length && !instance._initScrollAnimationFrameRequest) {
         var _instance$props$initS = instance.props.initScrollToIndex(),
             _index = _instance$props$initS.index,
             position = _instance$props$initS.position;
 
-        instance.scrollToItem(_index, position);
-        instance.setState({
-          scrolledToInitIndex: true
+        instance.scrollToItem(_index, position); // Adding a frame difference so UI settles
+        // The number of items usually rendered are more than the items rendered on load becuase of limit in initRangeToRender
+        // This is used for scrolling to the position and then the flags _keepScrollPosition, _keepScrollToBottom are used to keep position
+        // while new items are rendered after the first mount because if difference in initRangeToRender and OVERSCAN_COUNT_BACKWARD, OVERSCAN_COUNT_FORWARD
+
+        instance._initScrollAnimationFrameRequest = window.requestAnimationFrame(function () {
+          instance.setState({
+            scrolledToInitIndex: true
+          });
         });
 
         if (_index === 0) {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -74,6 +74,7 @@ function createListComponent(_ref) {
       _this._scrollByCorrection = null;
       _this._keepScrollPosition = false;
       _this._keepScrollToBottom = false;
+      _this._initScrollAnimationFrameRequest = null;
       _this.state = {
         scrollDirection: 'backward',
         scrollOffset: typeof _this.props.initialScrollOffset === 'number' ? _this.props.initialScrollOffset : 0,
@@ -1083,14 +1084,20 @@ createListComponent({
     };
 
     instance._commitHook = function () {
-      if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length) {
+      if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length && !instance._initScrollAnimationFrameRequest) {
         var _instance$props$initS = instance.props.initScrollToIndex(),
             _index = _instance$props$initS.index,
             position = _instance$props$initS.position;
 
-        instance.scrollToItem(_index, position);
-        instance.setState({
-          scrolledToInitIndex: true
+        instance.scrollToItem(_index, position); // Adding a frame difference so UI settles
+        // The number of items usually rendered are more than the items rendered on load becuase of limit in initRangeToRender
+        // This is used for scrolling to the position and then the flags _keepScrollPosition, _keepScrollToBottom are used to keep position
+        // while new items are rendered after the first mount because if difference in initRangeToRender and OVERSCAN_COUNT_BACKWARD, OVERSCAN_COUNT_FORWARD
+
+        instance._initScrollAnimationFrameRequest = window.requestAnimationFrame(function () {
+          instance.setState({
+            scrolledToInitIndex: true
+          });
         });
 
         if (_index === 0) {

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -368,7 +368,7 @@ const DynamicSizeList = createListComponent({
         instance.scrollToItem(index, position);
 
         // Adding a frame difference so UI settles
-        // The number of items usually rendered are more than the items rendered on load becuase of limit in initRangeToRender
+        // The number of items usually rendered are more than the items rendered on load because of limit in initRangeToRender
         // This is used for scrolling to the position and then the flags _keepScrollPosition, _keepScrollToBottom are used to keep position
         // while new items are rendered after the first mount because if difference in initRangeToRender and OVERSCAN_COUNT_BACKWARD, OVERSCAN_COUNT_FORWARD
         instance._initScrollAnimationFrameRequest = window.requestAnimationFrame(

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -361,13 +361,23 @@ const DynamicSizeList = createListComponent({
     instance._commitHook = () => {
       if (
         !instance.state.scrolledToInitIndex &&
-        Object.keys(instanceProps.itemOffsetMap).length
+        Object.keys(instanceProps.itemOffsetMap).length &&
+        !instance._initScrollAnimationFrameRequest
       ) {
         const { index, position } = instance.props.initScrollToIndex();
         instance.scrollToItem(index, position);
-        instance.setState({
-          scrolledToInitIndex: true,
-        });
+
+        // Adding a frame difference so UI settles
+        // The number of items usually rendered are more than the items rendered on load becuase of limit in initRangeToRender
+        // This is used for scrolling to the position and then the flags _keepScrollPosition, _keepScrollToBottom are used to keep position
+        // while new items are rendered after the first mount because if difference in initRangeToRender and OVERSCAN_COUNT_BACKWARD, OVERSCAN_COUNT_FORWARD
+        instance._initScrollAnimationFrameRequest = window.requestAnimationFrame(
+          () => {
+            instance.setState({
+              scrolledToInitIndex: true,
+            });
+          }
+        );
 
         if (index === 0) {
           instance._keepScrollToBottom = true;

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -129,6 +129,8 @@ export default function createListComponent({
     _scrollByCorrection = null;
     _keepScrollPosition = false;
     _keepScrollToBottom = false;
+    _initScrollAnimationFrameRequest = null;
+
     static defaultProps = {
       direction: 'vertical',
       innerTagName: 'div',


### PR DESCRIPTION
Adding a delay for `initScrollIndex` state set. With the removal of state in react this causes a minor discrepancy with mount of virt list.

If mount has more than X number of posts then there is a specific range we mount which is different compared to overSanCounts. The setState here is responsible for maintaining position when transitioning from first mount to adding more posts in second react update.

The delay here will make virt list settle before mounting more posts off the screen