### PR TITLE
Revert "MM-17385 Adding a delay in animationFrame for initScrollIndex state set"

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -265,6 +265,7 @@ function createListComponent(_ref) {
           _this2.scrollBy(_this2.state.scrollOffset, _this2.state.scrollByValue)();
         }
       });
+      this.forceUpdate();
     };
 
     _proto.scrollToItem = function scrollToItem(index, align) {

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -81,7 +81,6 @@ function createListComponent(_ref) {
       _this._scrollByCorrection = null;
       _this._keepScrollPosition = false;
       _this._keepScrollToBottom = false;
-      _this._initScrollAnimationFrameRequest = null;
       _this.state = {
         scrollDirection: 'backward',
         scrollOffset: typeof _this.props.initialScrollOffset === 'number' ? _this.props.initialScrollOffset : 0,
@@ -1091,20 +1090,14 @@ createListComponent({
     };
 
     instance._commitHook = function () {
-      if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length && !instance._initScrollAnimationFrameRequest) {
+      if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length) {
         var _instance$props$initS = instance.props.initScrollToIndex(),
             _index = _instance$props$initS.index,
             position = _instance$props$initS.position;
 
-        instance.scrollToItem(_index, position); // Adding a frame difference so UI settles
-        // The number of items usually rendered are more than the items rendered on load becuase of limit in initRangeToRender
-        // This is used for scrolling to the position and then the flags _keepScrollPosition, _keepScrollToBottom are used to keep position
-        // while new items are rendered after the first mount because if difference in initRangeToRender and OVERSCAN_COUNT_BACKWARD, OVERSCAN_COUNT_FORWARD
-
-        instance._initScrollAnimationFrameRequest = window.requestAnimationFrame(function () {
-          instance.setState({
-            scrolledToInitIndex: true
-          });
+        instance.scrollToItem(_index, position);
+        instance.setState({
+          scrolledToInitIndex: true
         });
 
         if (_index === 0) {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -74,7 +74,6 @@ function createListComponent(_ref) {
       _this._scrollByCorrection = null;
       _this._keepScrollPosition = false;
       _this._keepScrollToBottom = false;
-      _this._initScrollAnimationFrameRequest = null;
       _this.state = {
         scrollDirection: 'backward',
         scrollOffset: typeof _this.props.initialScrollOffset === 'number' ? _this.props.initialScrollOffset : 0,
@@ -1084,20 +1083,14 @@ createListComponent({
     };
 
     instance._commitHook = function () {
-      if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length && !instance._initScrollAnimationFrameRequest) {
+      if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length) {
         var _instance$props$initS = instance.props.initScrollToIndex(),
             _index = _instance$props$initS.index,
             position = _instance$props$initS.position;
 
-        instance.scrollToItem(_index, position); // Adding a frame difference so UI settles
-        // The number of items usually rendered are more than the items rendered on load becuase of limit in initRangeToRender
-        // This is used for scrolling to the position and then the flags _keepScrollPosition, _keepScrollToBottom are used to keep position
-        // while new items are rendered after the first mount because if difference in initRangeToRender and OVERSCAN_COUNT_BACKWARD, OVERSCAN_COUNT_FORWARD
-
-        instance._initScrollAnimationFrameRequest = window.requestAnimationFrame(function () {
-          instance.setState({
-            scrolledToInitIndex: true
-          });
+        instance.scrollToItem(_index, position);
+        instance.setState({
+          scrolledToInitIndex: true
         });
 
         if (_index === 0) {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -258,6 +258,7 @@ function createListComponent(_ref) {
           _this2.scrollBy(_this2.state.scrollOffset, _this2.state.scrollByValue)();
         }
       });
+      this.forceUpdate();
     };
 
     _proto.scrollToItem = function scrollToItem(index, align) {

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -361,23 +361,13 @@ const DynamicSizeList = createListComponent({
     instance._commitHook = () => {
       if (
         !instance.state.scrolledToInitIndex &&
-        Object.keys(instanceProps.itemOffsetMap).length &&
-        !instance._initScrollAnimationFrameRequest
+        Object.keys(instanceProps.itemOffsetMap).length
       ) {
         const { index, position } = instance.props.initScrollToIndex();
         instance.scrollToItem(index, position);
-
-        // Adding a frame difference so UI settles
-        // The number of items usually rendered are more than the items rendered on load because of limit in initRangeToRender
-        // This is used for scrolling to the position and then the flags _keepScrollPosition, _keepScrollToBottom are used to keep position
-        // while new items are rendered after the first mount because if difference in initRangeToRender and OVERSCAN_COUNT_BACKWARD, OVERSCAN_COUNT_FORWARD
-        instance._initScrollAnimationFrameRequest = window.requestAnimationFrame(
-          () => {
-            instance.setState({
-              scrolledToInitIndex: true,
-            });
-          }
-        );
+        instance.setState({
+          scrolledToInitIndex: true,
+        });
 
         if (index === 0) {
           instance._keepScrollToBottom = true;

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -201,6 +201,8 @@ export default function createListComponent({
           }
         }
       );
+
+      this.forceUpdate();
     }
 
     scrollToItem(index: number, align: ScrollToAlign = 'auto'): void {

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -129,8 +129,6 @@ export default function createListComponent({
     _scrollByCorrection = null;
     _keepScrollPosition = false;
     _keepScrollToBottom = false;
-    _initScrollAnimationFrameRequest = null;
-
     static defaultProps = {
       direction: 'vertical',
       innerTagName: 'div',


### PR DESCRIPTION
Reverts mattermost/react-window#22. This was initially added so that scrollTo will be done before setting scrolledToInitIndex but delaying setting the state has odd effects such as https://mattermost.atlassian.net/browse/MM-17780. Instead updating the scrollTo first by forcing an update instead of delaying state of scrolledToInitIndex

Changes for this PR are in https://github.com/mattermost/react-window/pull/23/commits/40d753e9330d932e08768b5ffb8d826e0d9dab23

