### PR TITLE
MM-18860 Remove ItemMeasurer.shouldComponentUpdate

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -5,8 +5,8 @@ Object.defineProperty(exports, '__esModule', { value: true });
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
 var _extends = _interopDefault(require('@babel/runtime/helpers/extends'));
-var _inheritsLoose = _interopDefault(require('@babel/runtime/helpers/inheritsLoose'));
 var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
+var _inheritsLoose = _interopDefault(require('@babel/runtime/helpers/inheritsLoose'));
 var memoizeOne = _interopDefault(require('memoize-one'));
 var React = require('react');
 var React__default = _interopDefault(React);
@@ -75,7 +75,7 @@ function createListComponent(_ref) {
       var _this;
 
       _this = _PureComponent.call(this, props) || this;
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
       _this._outerRef = void 0;
       _this._scrollCorrectionInProgress = false;
       _this._scrollByCorrection = null;
@@ -231,7 +231,7 @@ function createListComponent(_ref) {
         }
       };
 
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
       return _this;
     }
 
@@ -755,14 +755,6 @@ function (_Component) {
     }
   };
 
-  _proto.shouldComponentUpdate = function shouldComponentUpdate(nextProps) {
-    if (nextProps.width !== this.props.width || nextProps.size !== this.props.size || nextProps.itemCount !== this.props.itemCount) {
-      return true;
-    }
-
-    return false;
-  };
-
   _proto.componentDidUpdate = function componentDidUpdate(prevProps) {
     if (prevProps.size === 0 && this.props.size !== 0 || prevProps.size !== this.props.size) {
       this.positionScrollBars();
@@ -1256,7 +1248,7 @@ function createGridComponent(_ref2) {
       var _this;
 
       _this = _PureComponent.call(this, props) || this;
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
       _this._resetIsScrollingTimeoutId = null;
       _this._outerRef = void 0;
       _this.state = {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,6 +1,6 @@
 import _extends from '@babel/runtime/helpers/esm/extends';
-import _inheritsLoose from '@babel/runtime/helpers/esm/inheritsLoose';
 import _assertThisInitialized from '@babel/runtime/helpers/esm/assertThisInitialized';
+import _inheritsLoose from '@babel/runtime/helpers/esm/inheritsLoose';
 import memoizeOne from 'memoize-one';
 import React, { createElement, PureComponent, Component } from 'react';
 import { findDOMNode } from 'react-dom';
@@ -68,7 +68,7 @@ function createListComponent(_ref) {
       var _this;
 
       _this = _PureComponent.call(this, props) || this;
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
       _this._outerRef = void 0;
       _this._scrollCorrectionInProgress = false;
       _this._scrollByCorrection = null;
@@ -224,7 +224,7 @@ function createListComponent(_ref) {
         }
       };
 
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
       return _this;
     }
 
@@ -748,14 +748,6 @@ function (_Component) {
     }
   };
 
-  _proto.shouldComponentUpdate = function shouldComponentUpdate(nextProps) {
-    if (nextProps.width !== this.props.width || nextProps.size !== this.props.size || nextProps.itemCount !== this.props.itemCount) {
-      return true;
-    }
-
-    return false;
-  };
-
   _proto.componentDidUpdate = function componentDidUpdate(prevProps) {
     if (prevProps.size === 0 && this.props.size !== 0 || prevProps.size !== this.props.size) {
       this.positionScrollBars();
@@ -1249,7 +1241,7 @@ function createGridComponent(_ref2) {
       var _this;
 
       _this = _PureComponent.call(this, props) || this;
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
       _this._resetIsScrollingTimeoutId = null;
       _this._outerRef = void 0;
       _this.state = {

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -135,17 +135,6 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
     }
   }
 
-  shouldComponentUpdate(nextProps) {
-    if (
-      nextProps.width !== this.props.width ||
-      nextProps.size !== this.props.size ||
-      nextProps.itemCount !== this.props.itemCount
-    ) {
-      return true;
-    }
-    return false;
-  }
-
   componentDidUpdate(prevProps) {
     if (
       (prevProps.size === 0 && this.props.size !== 0) ||


### PR DESCRIPTION
As discussed with Sudheer earlier, this was causing the child of `ItemMeasurer` (the `renderRow` method of the `PostListVirtualized` component) to not re-render correctly. This ended up being a lot easier to fix than the original plan to refactor the post list logic heavily.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18860