### PR TITLE
Add offset and a callback for scrollToFailed

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -5,8 +5,8 @@ Object.defineProperty(exports, '__esModule', { value: true });
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
 var _extends = _interopDefault(require('@babel/runtime/helpers/extends'));
-var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
 var _inheritsLoose = _interopDefault(require('@babel/runtime/helpers/inheritsLoose'));
+var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
 var memoizeOne = _interopDefault(require('memoize-one'));
 var React = require('react');
 var React__default = _interopDefault(React);
@@ -75,7 +75,7 @@ function createListComponent(_ref) {
       var _this;
 
       _this = _PureComponent.call(this, props) || this;
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       _this._outerRef = void 0;
       _this._scrollCorrectionInProgress = false;
       _this._scrollByCorrection = null;
@@ -231,7 +231,7 @@ function createListComponent(_ref) {
         }
       };
 
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       return _this;
     }
 
@@ -268,9 +268,13 @@ function createListComponent(_ref) {
       this.forceUpdate();
     };
 
-    _proto.scrollToItem = function scrollToItem(index, align) {
+    _proto.scrollToItem = function scrollToItem(index, align, offset) {
       if (align === void 0) {
         align = 'auto';
+      }
+
+      if (offset === void 0) {
+        offset = 0;
       }
 
       var scrollOffset = this.state.scrollOffset; //Ideally the below scrollTo works fine but firefox has 6px issue and stays 6px from bottom when corrected
@@ -283,7 +287,7 @@ function createListComponent(_ref) {
         return;
       }
 
-      this.scrollTo(getOffsetForIndexAndAlignment(this.props, index, align, scrollOffset, this._instanceProps));
+      this.scrollTo(getOffsetForIndexAndAlignment(this.props, index, align, scrollOffset, this._instanceProps) + offset);
     };
 
     _proto.componentDidMount = function componentDidMount() {
@@ -1086,9 +1090,10 @@ createListComponent({
       if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length) {
         var _instance$props$initS = instance.props.initScrollToIndex(),
             _index = _instance$props$initS.index,
-            position = _instance$props$initS.position;
+            position = _instance$props$initS.position,
+            offset = _instance$props$initS.offset;
 
-        instance.scrollToItem(_index, position);
+        instance.scrollToItem(_index, position, offset);
         instance.setState({
           scrolledToInitIndex: true
         });
@@ -1248,7 +1253,7 @@ function createGridComponent(_ref2) {
       var _this;
 
       _this = _PureComponent.call(this, props) || this;
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       _this._resetIsScrollingTimeoutId = null;
       _this._outerRef = void 0;
       _this.state = {

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -292,8 +292,8 @@ function createListComponent(_ref) {
       if (!offsetOfItem) {
         var itemSize = getItemSize(this.props, index, this._instanceProps);
 
-        if (!itemSize && this.props.scrollTofailed) {
-          this.props.scrollTofailed(index);
+        if (!itemSize && this.props.scrollToFailed) {
+          this.props.scrollToFailed(index);
         }
       }
 

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -287,7 +287,17 @@ function createListComponent(_ref) {
         return;
       }
 
-      this.scrollTo(getOffsetForIndexAndAlignment(this.props, index, align, scrollOffset, this._instanceProps) + offset);
+      var offsetOfItem = getOffsetForIndexAndAlignment(this.props, index, align, scrollOffset, this._instanceProps);
+
+      if (!offsetOfItem) {
+        var itemSize = getItemSize(this.props, index, this._instanceProps);
+
+        if (!itemSize && this.props.scrollTofailed) {
+          this.props.scrollTofailed(index);
+        }
+      }
+
+      this.scrollTo(offsetOfItem + offset);
     };
 
     _proto.componentDidMount = function componentDidMount() {
@@ -327,12 +337,14 @@ function createListComponent(_ref) {
         var _this$state = this.state,
             _scrollDirection = _this$state.scrollDirection,
             _scrollOffset = _this$state.scrollOffset,
-            _scrollUpdateWasRequested = _this$state.scrollUpdateWasRequested;
+            _scrollUpdateWasRequested = _this$state.scrollUpdateWasRequested,
+            _scrollHeight = _this$state.scrollHeight;
         var prevScrollDirection = prevState.scrollDirection,
             prevScrollOffset = prevState.scrollOffset,
-            prevScrollUpdateWasRequested = prevState.scrollUpdateWasRequested;
+            prevScrollUpdateWasRequested = prevState.scrollUpdateWasRequested,
+            previousScrollHeight = prevState.scrollHeight;
 
-        if (_scrollDirection !== prevScrollDirection || _scrollOffset !== prevScrollOffset || _scrollUpdateWasRequested !== prevScrollUpdateWasRequested) {
+        if (_scrollDirection !== prevScrollDirection || _scrollOffset !== prevScrollOffset || _scrollUpdateWasRequested !== prevScrollUpdateWasRequested || _scrollHeight !== previousScrollHeight) {
           this._callPropsCallbacks();
         }
 

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -280,7 +280,17 @@ function createListComponent(_ref) {
         return;
       }
 
-      this.scrollTo(getOffsetForIndexAndAlignment(this.props, index, align, scrollOffset, this._instanceProps) + offset);
+      var offsetOfItem = getOffsetForIndexAndAlignment(this.props, index, align, scrollOffset, this._instanceProps);
+
+      if (!offsetOfItem) {
+        var itemSize = getItemSize(this.props, index, this._instanceProps);
+
+        if (!itemSize && this.props.scrollTofailed) {
+          this.props.scrollTofailed(index);
+        }
+      }
+
+      this.scrollTo(offsetOfItem + offset);
     };
 
     _proto.componentDidMount = function componentDidMount() {
@@ -320,12 +330,14 @@ function createListComponent(_ref) {
         var _this$state = this.state,
             _scrollDirection = _this$state.scrollDirection,
             _scrollOffset = _this$state.scrollOffset,
-            _scrollUpdateWasRequested = _this$state.scrollUpdateWasRequested;
+            _scrollUpdateWasRequested = _this$state.scrollUpdateWasRequested,
+            _scrollHeight = _this$state.scrollHeight;
         var prevScrollDirection = prevState.scrollDirection,
             prevScrollOffset = prevState.scrollOffset,
-            prevScrollUpdateWasRequested = prevState.scrollUpdateWasRequested;
+            prevScrollUpdateWasRequested = prevState.scrollUpdateWasRequested,
+            previousScrollHeight = prevState.scrollHeight;
 
-        if (_scrollDirection !== prevScrollDirection || _scrollOffset !== prevScrollOffset || _scrollUpdateWasRequested !== prevScrollUpdateWasRequested) {
+        if (_scrollDirection !== prevScrollDirection || _scrollOffset !== prevScrollOffset || _scrollUpdateWasRequested !== prevScrollUpdateWasRequested || _scrollHeight !== previousScrollHeight) {
           this._callPropsCallbacks();
         }
 

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -285,8 +285,8 @@ function createListComponent(_ref) {
       if (!offsetOfItem) {
         var itemSize = getItemSize(this.props, index, this._instanceProps);
 
-        if (!itemSize && this.props.scrollTofailed) {
-          this.props.scrollTofailed(index);
+        if (!itemSize && this.props.scrollToFailed) {
+          this.props.scrollToFailed(index);
         }
       }
 

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,6 +1,6 @@
 import _extends from '@babel/runtime/helpers/esm/extends';
-import _assertThisInitialized from '@babel/runtime/helpers/esm/assertThisInitialized';
 import _inheritsLoose from '@babel/runtime/helpers/esm/inheritsLoose';
+import _assertThisInitialized from '@babel/runtime/helpers/esm/assertThisInitialized';
 import memoizeOne from 'memoize-one';
 import React, { createElement, PureComponent, Component } from 'react';
 import { findDOMNode } from 'react-dom';
@@ -68,7 +68,7 @@ function createListComponent(_ref) {
       var _this;
 
       _this = _PureComponent.call(this, props) || this;
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       _this._outerRef = void 0;
       _this._scrollCorrectionInProgress = false;
       _this._scrollByCorrection = null;
@@ -224,7 +224,7 @@ function createListComponent(_ref) {
         }
       };
 
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       return _this;
     }
 
@@ -261,9 +261,13 @@ function createListComponent(_ref) {
       this.forceUpdate();
     };
 
-    _proto.scrollToItem = function scrollToItem(index, align) {
+    _proto.scrollToItem = function scrollToItem(index, align, offset) {
       if (align === void 0) {
         align = 'auto';
+      }
+
+      if (offset === void 0) {
+        offset = 0;
       }
 
       var scrollOffset = this.state.scrollOffset; //Ideally the below scrollTo works fine but firefox has 6px issue and stays 6px from bottom when corrected
@@ -276,7 +280,7 @@ function createListComponent(_ref) {
         return;
       }
 
-      this.scrollTo(getOffsetForIndexAndAlignment(this.props, index, align, scrollOffset, this._instanceProps));
+      this.scrollTo(getOffsetForIndexAndAlignment(this.props, index, align, scrollOffset, this._instanceProps) + offset);
     };
 
     _proto.componentDidMount = function componentDidMount() {
@@ -1079,9 +1083,10 @@ createListComponent({
       if (!instance.state.scrolledToInitIndex && Object.keys(instanceProps.itemOffsetMap).length) {
         var _instance$props$initS = instance.props.initScrollToIndex(),
             _index = _instance$props$initS.index,
-            position = _instance$props$initS.position;
+            position = _instance$props$initS.position,
+            offset = _instance$props$initS.offset;
 
-        instance.scrollToItem(_index, position);
+        instance.scrollToItem(_index, position, offset);
         instance.setState({
           scrolledToInitIndex: true
         });
@@ -1241,7 +1246,7 @@ function createGridComponent(_ref2) {
       var _this;
 
       _this = _PureComponent.call(this, props) || this;
-      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
+      _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_assertThisInitialized(_this)));
       _this._resetIsScrollingTimeoutId = null;
       _this._outerRef = void 0;
       _this.state = {

--- a/src/DynamicSizeList.js
+++ b/src/DynamicSizeList.js
@@ -363,8 +363,8 @@ const DynamicSizeList = createListComponent({
         !instance.state.scrolledToInitIndex &&
         Object.keys(instanceProps.itemOffsetMap).length
       ) {
-        const { index, position } = instance.props.initScrollToIndex();
-        instance.scrollToItem(index, position);
+        const { index, position, offset } = instance.props.initScrollToIndex();
+        instance.scrollToItem(index, position, offset);
         instance.setState({
           scrolledToInitIndex: true,
         });

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -228,8 +228,8 @@ export default function createListComponent({
       );
       if (!offsetOfItem) {
         const itemSize = getItemSize(this.props, index, this._instanceProps);
-        if (!itemSize && this.props.scrollTofailed) {
-          this.props.scrollTofailed(index);
+        if (!itemSize && this.props.scrollToFailed) {
+          this.props.scrollToFailed(index);
         }
       }
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -219,16 +219,21 @@ export default function createListComponent({
         this.scrollTo(element.scrollHeight - this.props.height);
         return;
       }
-
-      this.scrollTo(
-        getOffsetForIndexAndAlignment(
-          this.props,
-          index,
-          align,
-          scrollOffset,
-          this._instanceProps
-        ) + offset
+      const offsetOfItem = getOffsetForIndexAndAlignment(
+        this.props,
+        index,
+        align,
+        scrollOffset,
+        this._instanceProps
       );
+      if (!offsetOfItem) {
+        const itemSize = getItemSize(this.props, index, this._instanceProps);
+        if (!itemSize && this.props.scrollTofailed) {
+          this.props.scrollTofailed(index);
+        }
+      }
+
+      this.scrollTo(offsetOfItem + offset);
     }
 
     componentDidMount() {
@@ -270,18 +275,21 @@ export default function createListComponent({
           scrollDirection,
           scrollOffset,
           scrollUpdateWasRequested,
+          scrollHeight,
         } = this.state;
 
         const {
           scrollDirection: prevScrollDirection,
           scrollOffset: prevScrollOffset,
           scrollUpdateWasRequested: prevScrollUpdateWasRequested,
+          scrollHeight: previousScrollHeight,
         } = prevState;
 
         if (
           scrollDirection !== prevScrollDirection ||
           scrollOffset !== prevScrollOffset ||
-          scrollUpdateWasRequested !== prevScrollUpdateWasRequested
+          scrollUpdateWasRequested !== prevScrollUpdateWasRequested ||
+          scrollHeight !== previousScrollHeight
         ) {
           this._callPropsCallbacks();
         }

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -205,7 +205,11 @@ export default function createListComponent({
       this.forceUpdate();
     }
 
-    scrollToItem(index: number, align: ScrollToAlign = 'auto'): void {
+    scrollToItem(
+      index: number,
+      align: ScrollToAlign = 'auto',
+      offset = 0
+    ): void {
       const { scrollOffset } = this.state;
 
       //Ideally the below scrollTo works fine but firefox has 6px issue and stays 6px from bottom when corrected
@@ -223,7 +227,7 @@ export default function createListComponent({
           align,
           scrollOffset,
           this._instanceProps
-        )
+        ) + offset
       );
     }
 


### PR DESCRIPTION
#### Summary
This PR makes couple of changes
1. Accepts an offset for scroll correction so we can position new message line under toast
2. Adds a callback scrollToFailed so it can used to check if the post is not mounted for scroll correction. 

https://github.com/mattermost/mattermost-webapp/pull/4628
