### PR TITLE
MM-22698 Dont call for scrollToFailed when initial scroll is not done

### DIFF
--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -229,7 +229,15 @@ export default function createListComponent({
       if (!offsetOfItem) {
         const itemSize = getItemSize(this.props, index, this._instanceProps);
         if (!itemSize && this.props.scrollToFailed) {
-          this.props.scrollToFailed(index);
+          if (this.state.scrolledToInitIndex) {
+            this.props.scrollToFailed(index);
+          } else {
+            console.warn(
+              'Failed to do initial scroll correction',
+              this.props.initRangeToRender,
+              index
+            );
+          }
         }
       }
 


### PR DESCRIPTION
#### Summary
Removing the scrollToFailed if initial scroll correction is not performed. This mostly is the reason for users getting stuck with `Loading...`

The `scrollToFailed` method was particularly added for cases such as going to new messages(This will fail as it might not have mounted if it is out of virt window and we cannot scroll to posts which haven't mounted) from way up in the channel.
https://github.com/mattermost/mattermost-webapp/blob/78d609970bdf73050e0d59a651ac7a9d0a9c70d1/components/post_view/post_list_virtualized/post_list_virtualized.jsx#L324-L330

But from the reports and latest changes all i see is this function being the culprit as we are using it as 

```
    scrollToFailed = (index) => {
        if (index === 0) {
            this.props.actions.changeUnreadChunkTimeStamp('');
        } else {
            this.props.actions.changeUnreadChunkTimeStamp(this.props.lastViewedAt);
        }
    }
```

So we might be causing a recurring loop of `changeUnreadChunkTimeStamp` on first load scroll fail causing it to change the chunk of posts to be selected. 

**Solution**: Do not call the `scrollToFailed` callback before first scroll correction happens and log if this happens

**Effects of the PR**: We might see cases where first scroll correction fails but this was addded in 5.20v so we will be going back to how it was.

My theory is partly based on the reports so far where users had this issue and zooming in to the view fixed it. So this mostly should be based on virt list issue with higher screen resolutions

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22698